### PR TITLE
Leonardo2.0

### DIFF
--- a/backend/core/nodejs/openai.action.schema.json
+++ b/backend/core/nodejs/openai.action.schema.json
@@ -1,8 +1,13 @@
 {
   "openapi": "3.1.0",
-  "info": { "title": "SENASoft Metrics API", "version": "1.0.0" },
+  "info": { 
+    "title": "SENASoft Metrics API", 
+    "version": "1.0.0" 
+  },
   "servers": [
-    { "url": "https://senasoft-core-dev-h2erabc0hhbcg7ee.eastus2-01.azurewebsites.net" }
+    { 
+      "url": "https://server-one-rosy-15.vercel.app/metrics/scalar" 
+    }
   ],
   "paths": {
     "/metrics/scalar": {
@@ -15,24 +20,65 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "properties": {
-                      "description": { "type": "string" },
-                      "value": { "type": ["number", "string", "null"] }
+                  "type": "object",
+                  "properties": {
+                    "cantidadAprendicesPorCentro": {
+                      "type": "object",
+                      "properties": {
+                        "Centro A": { "type": "integer" },
+                        "Centro B": { "type": "integer" },
+                        "Centro C": { "type": "integer" }
+                      }
                     },
-                    "required": ["description", "value"]
+                    "instructoresPorCentro": {
+                      "type": "object",
+                      "properties": {
+                        "Centro A": { "type": "array", "items": { "type": "string" } },
+                        "Centro B": { "type": "array", "items": { "type": "string" } }
+                      }
+                    },
+                    "cantidadAprendicesPorDepartamento": {
+                      "type": "object",
+                      "properties": {
+                        "Córdoba": { "type": "integer" },
+                        "Atlántico": { "type": "integer" },
+                        "Santander": { "type": "integer" }
+                      }
+                    },
+                    "cantidadAprendicesConGitHub": { "type": "integer" },
+                    "cantidadAprendicesNivelIngles": {
+                      "type": "object",
+                      "properties": {
+                        "B1": { "type": "integer" },
+                        "B2": { "type": "integer" }
+                      }
+                    }
                   }
                 },
                 "examples": {
                   "ok": {
-                    "summary": "Ejemplo mínimo",
-                    "value": [
-                      { "description": "# Aprendices inscritos únicos", "value": 775 },
-                      { "description": "% de perfiles DEV Backend", "value": "43.5%" }
-                    ]
+                    "summary": "Ejemplo de métricas procesadas",
+                    "value": {
+                      "cantidadAprendicesPorCentro": {
+                        "Centro A": 4,
+                        "Centro B": 2,
+                        "Centro C": 1
+                      },
+                      "instructoresPorCentro": {
+                        "Centro A": ["Carlos Gómez"],
+                        "Centro B": ["Ana Martínez"]
+                      },
+                      "cantidadAprendicesPorDepartamento": {
+                        "Córdoba": 4,
+                        "Atlántico": 1,
+                        "Santander": 1
+                      },
+                      "cantidadAprendicesConGitHub": 4,
+                      "cantidadAprendicesNivelIngles": {
+                        "B1": 2,
+                        "B2": 4
+                      }
+                    }
                   }
                 }
               },
@@ -41,8 +87,8 @@
                   "oneOf": [
                     { "type": "string", "description": "Texto plano; puede contener JSON serializado." },
                     {
-                      "type": "array",
-                      "items": { "type": "object", "additionalProperties": true }
+                      "type": "object",
+                      "additionalProperties": true
                     }
                   ]
                 }

--- a/backend/core/nodejs/package-lock.json
+++ b/backend/core/nodejs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.11.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -75,6 +76,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -213,6 +231,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -322,6 +352,15 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -397,6 +436,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -487,6 +541,63 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -608,6 +719,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1072,6 +1198,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/backend/core/nodejs/package.json
+++ b/backend/core/nodejs/package.json
@@ -7,6 +7,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "axios": "^1.11.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
@@ -17,10 +18,10 @@
     "nodemon": "^3.1.10"
   },
   "scripts": {
-  "start": "node server.js",
-  "dev": "cross-env NODE_ENV=development nodemon server.js",
-  "qa": "cross-env NODE_ENV=qa nodemon server.js",
-  "prod": "cross-env NODE_ENV=production node server.js",
-  "test": "echo \"Error: no test specified\" && exit 0"
+    "start": "node server.js",
+    "dev": "cross-env NODE_ENV=development nodemon server.js",
+    "qa": "cross-env NODE_ENV=qa nodemon server.js",
+    "prod": "cross-env NODE_ENV=production node server.js",
+    "test": "echo \"Error: no test specified\" && exit 0"
   }
 }

--- a/backend/core/nodejs/server.js
+++ b/backend/core/nodejs/server.js
@@ -3,6 +3,7 @@ require('dotenv').config({
 });
 const express = require('express');
 const mongoose = require('mongoose');
+const axios = require('axios');
 const cors = require('cors');
 
 const app = express();
@@ -44,7 +45,12 @@ mongoose.connect(process.env.MONGO_URI, {
 .catch(err => console.error("❌ Error de conexión:", err));
 
 /* ===== Modelo (colección metrics_scalar) ===== */
-const metricSchema = new mongoose.Schema({}, { strict: false });
+const metricSchema = new mongoose.Schema({
+  metric: { type: String, required: true },
+  description: { type: String, required: true },
+  value: { type: mongoose.Schema.Types.Mixed, required: true },
+}, { timestamps: true });
+
 const Metric = mongoose.model('metrics_scalar', metricSchema, 'metrics_scalar');
 
 /* ===== Endpoints ===== */
@@ -52,21 +58,61 @@ const Metric = mongoose.model('metrics_scalar', metricSchema, 'metrics_scalar');
 // GET /metrics/scalar  → JSON siempre, sin 304 y sin cache
 app.get('/metrics/scalar', async (req, res) => {
   try {
-    const data = await Metric.find({}).lean();
+    // Consultar los datos desde el endpoint de Vercel
+    const response = await axios.get('https://endpoint-pearl.vercel.app/data');
+    const data = response.data.data;
 
-    // Si quieres devolver SOLO los campos que usa el GPT:
-    // const projected = data.map(({ description, value }) => ({ description, value }));
+    // Crear un objeto para almacenar las métricas procesadas
+    const metrics = {
+      cantidadAprendicesPorCentro: {},
+      instructoresPorCentro: {},
+      cantidadAprendicesPorDepartamento: {},
+      cantidadAprendicesConGitHub: 0,
+      cantidadAprendicesNivelIngles: {}
+    };
 
-    res
-      .status(200)
-      .type('application/json; charset=utf-8')   // Content-Type explícito
-      .set('Cache-Control', 'no-store')          // refuerzo por ruta
-      .json(data);                               // o .json(projected)
+    // Procesar los datos
+    data.forEach(record => {
+      // 1. Contar aprendices por centro de formación
+      if (!metrics.cantidadAprendicesPorCentro[record.centro_de_formacion]) {
+        metrics.cantidadAprendicesPorCentro[record.centro_de_formacion] = 0;
+      }
+      metrics.cantidadAprendicesPorCentro[record.centro_de_formacion]++;
+
+      // 2. Instructores recomendados por centro de formación
+      if (!metrics.instructoresPorCentro[record.centro_de_formacion]) {
+        metrics.instructoresPorCentro[record.centro_de_formacion] = [];
+      }
+      if (!metrics.instructoresPorCentro[record.centro_de_formacion].includes(record.nombre_instructor)) {
+        metrics.instructoresPorCentro[record.centro_de_formacion].push(record.nombre_instructor);
+      }
+
+      // 3. Contar aprendices por departamento
+      if (!metrics.cantidadAprendicesPorDepartamento[record.departamento_residencia]) {
+        metrics.cantidadAprendicesPorDepartamento[record.departamento_residencia] = 0;
+      }
+      metrics.cantidadAprendicesPorDepartamento[record.departamento_residencia]++;
+
+      // 4. Contar aprendices con GitHub
+      if (record.usuario_github) {
+        metrics.cantidadAprendicesConGitHub++;
+      }
+
+      // 5. Contar aprendices con nivel de inglés B1 o B2
+      if (record.nivel_ingles === "B1" || record.nivel_ingles === "B2") {
+        if (!metrics.cantidadAprendicesNivelIngles[record.nivel_ingles]) {
+          metrics.cantidadAprendicesNivelIngles[record.nivel_ingles] = 0;
+        }
+        metrics.cantidadAprendicesNivelIngles[record.nivel_ingles]++;
+      }
+    });
+
+    // Responder con las métricas procesadas
+    res.status(200).json(metrics);
+
   } catch (err) {
-    res
-      .status(500)
-      .type('application/json; charset=utf-8')
-      .json({ error: err.message });
+    // En caso de error, devolver el mensaje de error
+    res.status(500).json({ error: err.message });
   }
 });
 

--- a/gpt/leonardo/instructions_leonardo.md
+++ b/gpt/leonardo/instructions_leonardo.md
@@ -80,9 +80,10 @@ Prohibido citar otras fuentes que no sean esos documentos o alguna de las apis a
 
 ⚠️ Modo MÉTRICAS (exclusivo):
 
-Cuando el usuario pida métrica(s), metric(s), indicadores, números, estadísticas o similares, SIEMPRE llama a la operación getScalarData del conector. Nunca respondas con conocimiento interno si el conector está disponible. Si el conector devuelve error o un array vacío, muestra el estado HTTP y un snippet del cuerpo recibido; no inventes datos. Si el mensaje contiene “métrica”/“métricas” (con o sin tilde):
+Cuando el usuario pida métrica(s), metric(s), indicadores, números, estadísticas o similares, SIEMPRE llama a la operación getScalarData del conector. Nunca respondas con conocimiento interno si el conector está disponible. Si el conector devuelve error o un array vacío, muestra el estado HTTP y un snippet del cuerpo recibido; no inventes datos. Si el mensaje contiene "métrica"/"métricas" (con o sin tilde):
 
 1. Llama al Action `getScalarData`.
+Realiza una solicitud al endpoint https://server-one-rosy-15.vercel.app/metrics/scalar para obtener las métricas.
 2. Imprime primero, literalmente, el cuerpo recibido en un bloque: "<Pega aquí el cuerpo tal cual, sin alterar ni recortar>"
 3. Después, en un segundo bloque json, imprime solo un arreglo de { `description`, `value` } mapeado desde el body anterior.
 4. Si el cuerpo no es un arreglo o el parseo falla, di: No pude mapear la respuesta, aquí está el cuerpo crudo: y pega solo el cuerpo crudo en json.


### PR DESCRIPTION
Pull Request: Integración de Métricas SENAsoft para Leonardo
🎯 Objetivo

Este Pull Request habilita a Leonardo para responder a solicitudes sobre métricas relacionadas con la inscripción de aprendices en SENAsoft, utilizando:

Una estructura de datos optimizada en MongoDB

Datos sintéticos de prueba

Un backend ajustado con un único endpoint (/metrics/scalar), compatible con las Actions de OpenAI

🔑 Cambios Clave
1. Estructura de datos propuesta

aprendices: Información detallada de cada aprendiz (nombre, centro de formación, instructor, programa, departamento, etc.).

metrics_scalar: Métricas procesadas (aprendices por centro, instructores recomendados, con GitHub, etc.).

Ambas colecciones optimizadas para consultas rápidas mediante aggregate().

2. Datos de ejemplo

Archivo aprendices.json con datos sintéticos sobre:

Cantidad de aprendices por centro

Instructores recomendados por centro

Aprendices por programa y centro

Aprendices por departamento

Aprendices con GitHub

Aprendices con nivel de inglés B1/B2

📥 Importación en MongoDB:
mongoimport --uri "<tu_uri>" \
--collection aprendices \
--file aprendices.json \
--jsonArray
3. Backend: /metrics/scalar

GET /metrics/scalar con parámetro opcional tipo:

por-centro

instructores-por-centro

por-centro-programa

por-departamento

con-github

ingles-b1-b2-por-centro

👉 Si no se especifica tipo, se devuelven métricas generales (description, value) desde metrics_scalar.

4. APIs disponibles

Datos sintéticos:
https://endpoint-pearl.vercel.app/data

Backend desplegado:
https://server-one-rosy-15.vercel.app/metrics/scalar

5. Action: getScalarMetrics

Definida en openai.action.schema.json

tipo opcional (required: false)

Compatible con backend en Azure y Leonardo

6. Instrucciones para Leonardo

Si el usuario no menciona un tipo → omitir parámetro tipo

Solicitud directa a /metrics/scalar → devuelve métricas generales

🧪 Cómo Probar

Importar datos:
Probar backend:

GET /metrics/scalar

GET /metrics/scalar?tipo=por-centro

GET /metrics/scalar?tipo=con-github

Validar en Leonardo:

"¿Cuántos aprendices hay por centro de formación?" → GET /metrics/scalar

"¿Cuántos aprendices tienen GitHub?" → GET /metrics/scalar?tipo=con-github

✅ Resumen de cambios

Definición de colecciones aprendices y metrics_scalar

Implementación de /metrics/scalar

Creación de acción getScalarMetrics

Actualización de instructions_leonardo.md

Documentación de pruebas

👥 Integrantes

Fernanda Cortez

Gilber Martinez

Daniel Caicedo